### PR TITLE
Changed the start-app test helper to use `Ember.assign`.

### DIFF
--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = Ember.assign({}, config.APP);
+  attributes = Ember.assign(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
Opening this PR as a way to start a small discussion. My sense is that `Ember.assign` is preferred over `Ember.merge` because it's just a polyfill for ES2015 `Object.assign`. For a very brief point in time `Ember.merge` was deprecated, but quickly deprecated because it created noise. 

Thoughts?